### PR TITLE
Feat/pass manager kwargs from namespace

### DIFF
--- a/src/socketio/asyncio_namespace.py
+++ b/src/socketio/asyncio_namespace.py
@@ -42,7 +42,7 @@ class AsyncNamespace(namespace.Namespace):
             return ret
 
     async def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-                   namespace=None, callback=None,**kwargs):
+                   namespace=None, callback=None, **kwargs):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -54,7 +54,7 @@ class AsyncNamespace(namespace.Namespace):
         return await self.server.emit(event, data=data, to=to, room=room,
                                       skip_sid=skip_sid,
                                       namespace=namespace or self.namespace,
-                                      callback=callback,**kwargs)
+                                      callback=callback, **kwargs)
 
     async def send(self, data, to=None, room=None, skip_sid=None,
                    namespace=None, callback=None):

--- a/src/socketio/asyncio_namespace.py
+++ b/src/socketio/asyncio_namespace.py
@@ -42,7 +42,7 @@ class AsyncNamespace(namespace.Namespace):
             return ret
 
     async def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-                   namespace=None, callback=None):
+                   namespace=None, callback=None,**kwargs):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -54,7 +54,7 @@ class AsyncNamespace(namespace.Namespace):
         return await self.server.emit(event, data=data, to=to, room=room,
                                       skip_sid=skip_sid,
                                       namespace=namespace or self.namespace,
-                                      callback=callback)
+                                      callback=callback,**kwargs)
 
     async def send(self, data, to=None, room=None, skip_sid=None,
                    namespace=None, callback=None):

--- a/src/socketio/namespace.py
+++ b/src/socketio/namespace.py
@@ -38,7 +38,7 @@ class Namespace(BaseNamespace):
         self.server = server
 
     def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-             namespace=None, callback=None,**kwargs):
+             namespace=None, callback=None, **kwargs):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -48,7 +48,7 @@ class Namespace(BaseNamespace):
         return self.server.emit(event, data=data, to=to, room=room,
                                 skip_sid=skip_sid,
                                 namespace=namespace or self.namespace,
-                                callback=callback,**kwargs)
+                                callback=callback, **kwargs)
 
     def send(self, data, to=None, room=None, skip_sid=None, namespace=None,
              callback=None):

--- a/src/socketio/namespace.py
+++ b/src/socketio/namespace.py
@@ -38,7 +38,7 @@ class Namespace(BaseNamespace):
         self.server = server
 
     def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-             namespace=None, callback=None):
+             namespace=None, callback=None,**kwargs):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -48,7 +48,7 @@ class Namespace(BaseNamespace):
         return self.server.emit(event, data=data, to=to, room=room,
                                 skip_sid=skip_sid,
                                 namespace=namespace or self.namespace,
-                                callback=callback)
+                                callback=callback,**kwargs)
 
     def send(self, data, to=None, room=None, skip_sid=None, namespace=None,
              callback=None):


### PR DESCRIPTION
# WHY
I need to pass `ignore_queue` from namespace emit call. 
# WHAT 
Pass kwargs from namespace emit to server emit